### PR TITLE
fix calculation of ROS topic subscriber count

### DIFF
--- a/camera_aravis2/src/camera_driver.cpp
+++ b/camera_aravis2/src/camera_driver.cpp
@@ -1085,6 +1085,7 @@ void CameraDriver::handleMessageSubscriptionChange(rclcpp::MatchedInfo& iEventIn
     }
 
     //--- get the maximum number of subscribers over all streams and assign to the member variable
+    current_num_subscribers_ = 0;
     for (uint i = 0; i < streams_.size(); ++i)
     {
         current_num_subscribers_ =


### PR DESCRIPTION
if a subscriber disconnected the node never noticed this since it always does an `std::max` on the current value and the subscriber count of each stream. this is meant to find the largest amount of subscribers over all stream but incorrectly never resets it to a lower value if the stream with the highest subscriber count had the now disconnected subscriber.

this is easiest to reproduce by having a single camera with a single stream and connecting to it with `image_view`: upon first launch the `camera_aravis2` node will write the debug message `Acquisition started`, after stopping `image_view` it logs `Acquisition stopped`. but when starting again `image_view` it no longer logs `Acquisition start` without this fix and no image is written to the ROS topic.


step-by-step reproduction case:
1. launch `camera_aravis2` for your camera (and enable debugging for more fine-grained information)
2. launch `image_view`: `ros2 run image_view image_view` ==> image is shown correctly, `camera_aravis2` logs `[DEBUG] -> Acquisition started.`
3. stop `image_view` ==> `camera_aravis2` logs `[DEBUG] -> Acquisition stopped.`
4. launch `image_view` again ==> no image is shown, no acquisition start in `camera_araivs2` log!
5. stop `image_view` ==> `camera_aravis2` logs `[DEBUG] -> Acquisition stopped.`

log excerpt (with manual annotation) without the fix:
```
[camera_driver_uv-1] 1733153020.380384020: [rcl] [DEBUG]        take_event request success
[camera_driver_uv-1] 1733153020.380431950: [camera_driver_cam1] [DEBUG] -> Acquisition started.
...
[camera_driver_uv-1] 1733153037.397883329: [rcl] [DEBUG]        take_event request success
[camera_driver_uv-1] 1733153037.397932792: [camera_driver_cam1] [DEBUG] -> Acquisition stopped.
...
[camera_driver_uv-1] 1733153054.810501974: [rcl] [DEBUG]        take_event request success
--> missing acquisition start message here! <--
...
[camera_driver_uv-1] 1733153063.572933840: [rcl] [DEBUG]        take_event request success
[camera_driver_uv-1] 1733153063.572986499: [camera_driver_cam1] [DEBUG] -> Acquisition stopped.
```