### PR TITLE
add support for triggering parameters

### DIFF
--- a/camera_aravis2/include/camera_aravis2/config_structs.h
+++ b/camera_aravis2/include/camera_aravis2/config_structs.h
@@ -162,6 +162,22 @@ struct AcquisitionControl
     /// Number of frames to acquire when 'MultiFrame' is selected as acquisition mode.
     int frame_count = 0;
 
+    /// Setting the mode for the selected trigger.
+    std::string trigger_mode = "n/a";
+
+    /// Setting the signal source for the selected trigger.
+    std::string trigger_source = "n/a";
+
+    /// Selects the I/O line to configure. Once a line has been selected, all changes to the line
+    /// settings will be applied to the selected line.
+    std::string line_selector = "n/a";
+
+    /// Sets the mode for the selected line.
+    std::string line_mode = "n/a";
+
+    /// Sets the source signal for the selected line (if the selected line is an output).
+    std::string line_source = "n/a";
+
     /// Exposure mode used for acquisition.
     std::string exposure_mode = "n/a";
 

--- a/camera_aravis2/src/camera_driver.cpp
+++ b/camera_aravis2/src/camera_driver.cpp
@@ -683,6 +683,71 @@ bool CameraDriver::setupCameraStreamStructs()
         //---   For bounded feature values (e.g. frame rate), use function that will also get
         //---   the bounds and truncate the value accordingly
 
+        //--- Trigger Mode
+        tmp_feature_name = "TriggerMode";
+        RCLCPP_DEBUG(logger_, "Evaluating 'AcquisitionControl.%s' for stream %i.",
+                     tmp_feature_name.c_str(), i);
+        is_parameter_set = getAcquisitionControlParameter(tmp_feature_name, tmp_param_value);
+        if (is_parameter_set)
+            setFeatureValueFromParameter<std::string>(tmp_feature_name, tmp_param_value, i);
+        getFeatureValue<std::string>(tmp_feature_name, acq_ctrl.trigger_mode);
+        if (is_parameter_set &&
+            !isParameterValueEqualTo<std::string>(tmp_param_value, acq_ctrl.trigger_mode, i))
+            config_warn_msgs_.push_back("Stream " + std::to_string(i) + ": " +
+            "'" + tmp_feature_name + "' is not as specified.");
+
+        //--- Trigger Source
+        tmp_feature_name = "TriggerSource";
+        RCLCPP_DEBUG(logger_, "Evaluating 'AcquisitionControl.%s' for stream %i.",
+                     tmp_feature_name.c_str(), i);
+        is_parameter_set = getAcquisitionControlParameter(tmp_feature_name, tmp_param_value);
+        if (is_parameter_set)
+            setFeatureValueFromParameter<std::string>(tmp_feature_name, tmp_param_value, i);
+        getFeatureValue<std::string>(tmp_feature_name, acq_ctrl.trigger_source);
+        if (is_parameter_set &&
+            !isParameterValueEqualTo<std::string>(tmp_param_value, acq_ctrl.trigger_source, i))
+            config_warn_msgs_.push_back("Stream " + std::to_string(i) + ": " +
+            "'" + tmp_feature_name + "' is not as specified.");
+
+        //--- Line Selector
+        tmp_feature_name = "LineSelector";
+        RCLCPP_DEBUG(logger_, "Evaluating 'AcquisitionControl.%s' for stream %i.",
+                     tmp_feature_name.c_str(), i);
+        is_parameter_set = getAcquisitionControlParameter(tmp_feature_name, tmp_param_value);
+        if (is_parameter_set)
+            setFeatureValueFromParameter<std::string>(tmp_feature_name, tmp_param_value, i);
+        getFeatureValue<std::string>(tmp_feature_name, acq_ctrl.line_selector);
+        if (is_parameter_set &&
+            !isParameterValueEqualTo<std::string>(tmp_param_value, acq_ctrl.line_selector, i))
+            config_warn_msgs_.push_back("Stream " + std::to_string(i) + ": " +
+            "'" + tmp_feature_name + "' is not as specified.");
+
+        //--- Line Mode
+        tmp_feature_name = "LineMode";
+        RCLCPP_DEBUG(logger_, "Evaluating 'AcquisitionControl.%s' for stream %i.",
+                     tmp_feature_name.c_str(), i);
+        is_parameter_set = getAcquisitionControlParameter(tmp_feature_name, tmp_param_value);
+        if (is_parameter_set)
+            setFeatureValueFromParameter<std::string>(tmp_feature_name, tmp_param_value, i);
+        getFeatureValue<std::string>(tmp_feature_name, acq_ctrl.line_mode);
+        if (is_parameter_set &&
+            !isParameterValueEqualTo<std::string>(tmp_param_value, acq_ctrl.line_mode, i))
+            config_warn_msgs_.push_back("Stream " + std::to_string(i) + ": " +
+            "'" + tmp_feature_name + "' is not as specified.");
+
+        //--- Line Source
+        tmp_feature_name = "LineSource";
+        RCLCPP_DEBUG(logger_, "Evaluating 'AcquisitionControl.%s' for stream %i.",
+                     tmp_feature_name.c_str(), i);
+        is_parameter_set = getAcquisitionControlParameter(tmp_feature_name, tmp_param_value);
+        if (is_parameter_set)
+            setFeatureValueFromParameter<std::string>(tmp_feature_name, tmp_param_value, i);
+        getFeatureValue<std::string>(tmp_feature_name, acq_ctrl.line_source);
+        if (is_parameter_set &&
+            !isParameterValueEqualTo<std::string>(tmp_param_value, acq_ctrl.line_source, i))
+            config_warn_msgs_.push_back("Stream " + std::to_string(i) + ": " +
+                                        "'" + tmp_feature_name + "' is not as specified.");
+
         //--- Acquisition Mode
         tmp_feature_name = "AcquisitionMode";
         RCLCPP_DEBUG(logger_, "Evaluating 'AcquisitionControl.%s' for stream %i.",
@@ -1978,6 +2043,16 @@ void CameraDriver::printCameraConfiguration() const
         if (is_verbose_enable_)
             RCLCPP_INFO(logger_, "    Image Height Bound:  [%i,%i]",
                         ROI.height_min, ROI.height_max);
+
+        RCLCPP_INFO(logger_, "    Trigger Mode:        %s", ACQ_CTRL.trigger_mode.c_str());
+
+        RCLCPP_INFO(logger_, "    Trigger Source:      %s", ACQ_CTRL.trigger_source.c_str());
+
+        RCLCPP_INFO(logger_, "    Line Selector:       %s", ACQ_CTRL.line_selector.c_str());
+
+        RCLCPP_INFO(logger_, "    Line Mode:           %s", ACQ_CTRL.line_mode.c_str());
+
+        RCLCPP_INFO(logger_, "    Line Source:         %s", ACQ_CTRL.line_source.c_str());
 
         RCLCPP_INFO(logger_, "    Acquisition Mode:    %s", ACQ_CTRL.acquisition_mode.c_str());
 


### PR DESCRIPTION
this allows setting the following AcquisitionControl parameters:
* TriggerMode
* TriggerSource
* LineSelector
* LineMode
* LineSource

with this it is possible to configure cameras to either issue trigger commands or receive them (or both).

see e.g. also [this post] from VAimaging about how to set this up with their cameras.

this was done as a quick-win, IMHO the proper solution is to implement support for arbitrary parameters (see #57).

[this post]: https://va-imaging.com/blogs/machine-vision-knowledge-center/i-o-control-how-to-hardware-trigger-a-machine-vision-camera-using-a-trigger-sensor-and-how-to-trigger-machine-vision-lights