### PR TITLE
cmake: Find aravis library with pkg-config if available

### DIFF
--- a/camera_aravis2/CMakeModules/FindARAVIS.cmake
+++ b/camera_aravis2/CMakeModules/FindARAVIS.cmake
@@ -16,6 +16,12 @@
 
 set(ARAVIS_VERSION 0.8)
 
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(ARAVIS aravis-${ARAVIS_VERSION})
+endif()
+
+if(NOT ARAVIS_FOUND)
 find_path(ARAVIS_INCLUDE_DIRS arv.h
   PATHS
   "$ENV{ARAVIS_INCLUDE_PATH}"
@@ -36,3 +42,4 @@ find_package_handle_standard_args( ARAVIS DEFAULT_MSG
   ARAVIS_INCLUDE_DIRS
   ARAVIS_LIBRARIES
 )
+endif() # if(NOT ARAVIS_FOUND)

--- a/camera_aravis2/package.xml
+++ b/camera_aravis2/package.xml
@@ -12,6 +12,7 @@
 
   <build_depend>aravis-dev</build_depend>
   <build_depend>libglib-dev</build_depend>
+  <build_depend>pkg-config</build_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
In some distributions (e.g. those using the Nix package manager) Aravis library is not located under the `/usr` directory, where this package expects it. Instead of requiring every user of such distributions setting the `ARAVIS_*` environment variables manually, use `pkg-config`, which allows finding the library automatically based on the standard environment variables like `PKG_CONFIG_PATH`.